### PR TITLE
add support for latex-style single and double quotes text objects

### DIFF
--- a/README.org
+++ b/README.org
@@ -86,6 +86,8 @@ This package defines a number of text objects:
 | ~^~ | superscript     | ~x^a~ ~x^\alpha~ ~x^{...}~                                               | Surrounds with ~^{ }~                      |
 | ~_~ | subscript       | ~x_a~ ~x_\alpha~ ~x_{...}~                                               | Surrounds with ~_{ }~                      |
 | ~T~ | table cell      | LaTeX table/align cells, e.g. ~&foo&~.                                   | Surrounds with ~& &~                       |
+| ~q~ | single quote    | LaTeX single quote, like `this'                                          | Surrounds with ~` '~                       |
+| ~Q~ | double quote    | LaTeX double quote, like ``this''                                        | Surrounds with ~`` ''~                     |
 
 The full text object definitions are as follows:
 
@@ -122,6 +124,10 @@ The full text object definitions are as follows:
     & foobar &    & foobar &    & foobar \\    & foobar \\    
     └───────┘      └──────┘     └───────┘       └──────┘
         aT            iT            aT             iT
+
+     `foobar'      `foobar'     ``foobar''     ``foobar''
+     └──────┘       └────┘      └────────┘       └────┘
+        aq            iq            aQ             iQ
 #+END_SRC LaTeX
 /The diagram rendering might bug out on mobile./
 

--- a/evil-tex.el
+++ b/evil-tex.el
@@ -738,6 +738,23 @@ when `org-mode' and `evil-org-mode' are enabled.")
   "Select inner LaTeX table cell."
   (last (evil-tex--select-table-cell) 2))
 
+(evil-define-text-object evil-tex-inner-single-latex-quote (count &optional beg end type)
+  "Select inner LaTeX `single quote'."
+  (evil-select-paren "`" "'" beg end type count nil))
+
+(evil-define-text-object evil-tex-a-single-latex-quote (count &optional beg end type)
+  "Select a LaTeX `single quote'."
+  (evil-select-paren "`" "'" beg end type count t))
+
+(evil-define-text-object evil-tex-inner-double-latex-quote (count &optional beg end type)
+  "Select inner LaTeX ``double quote''."
+  (evil-select-paren "``" "''" beg end type count nil))
+
+(evil-define-text-object evil-tex-a-double-latex-quote (count &optional beg end type)
+  "Select a LaTeX ``double quote''."
+  (evil-select-paren "``" "''" beg end type count t))
+
+
 
 ;;; evil-surround setup
 
@@ -919,6 +936,8 @@ Otherwise, with the macro constructed by REGULAR-FORMAT."
   (define-key inner-map "^" 'evil-tex-inner-superscript)
   (define-key inner-map "_" 'evil-tex-inner-subscript)
   (define-key inner-map "T" 'evil-tex-inner-table-cell)
+  (define-key inner-map "q" 'evil-tex-inner-single-latex-quote)
+  (define-key inner-map "Q" 'evil-tex-inner-double-latex-quote)
 
   (define-key outer-map "e" 'evil-tex-an-env)
   (define-key outer-map "c" 'evil-tex-a-command)
@@ -927,7 +946,9 @@ Otherwise, with the macro constructed by REGULAR-FORMAT."
   (define-key outer-map "S" 'evil-tex-a-section)
   (define-key outer-map "^" 'evil-tex-a-superscript)
   (define-key outer-map "_" 'evil-tex-a-subscript)
-  (define-key outer-map "T" 'evil-tex-a-table-cell))
+  (define-key outer-map "T" 'evil-tex-a-table-cell)
+  (define-key outer-map "q" 'evil-tex-a-single-latex-quote)
+  (define-key outer-map "Q" 'evil-tex-a-double-latex-quote))
 
 
 (defvar evil-tex-env-map (make-sparse-keymap)
@@ -1115,6 +1136,8 @@ explaination."
     (?e . ,#'evil-tex-surround-env-prompt)
     (?d . ,#'evil-tex-surround-delim-prompt)
     (?\; . ,#'evil-tex-surround-cdlatex-accents-prompt)
+    (?q "`" . "'")
+    (?Q "``" . "''")
     (?^ "^{" . "}")
     (?_ "_{" . "}")
     (?T "&" . "&"))


### PR DESCRIPTION
Create two new text objects: `single-latex-quote` and `double-latex-quote`,
available in both `inner` and `outer` flavors.

Map single quotes to q and double quotes to Q in the style of vim's
`textobj-latex` plugin.

Also support insertion using `evil-surround`, bound analogously to `q` and `Q`.
Update documentation to reflect new text object's

This should fix #15 (at least the quote part of it; textobj's for "item" still
on my todo list)