### PR TITLE
fix regex used in evil-tex-toggle-delim

### DIFF
--- a/evil-tex.el
+++ b/evil-tex.el
@@ -481,11 +481,11 @@ Also change e.g \\bigl(foo\bigr) to (foo), but this is one way."
         (goto-char (overlay-start left-over))
         (cl-destructuring-bind (l . r)
             (cond
-             ((looking-at "\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)?l?" )
+             ((looking-at "\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)" )
               (cons (replace-regexp-in-string
-                     "\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)?l?" "" left-str)
+                     "\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)" "" left-str)
                     (replace-regexp-in-string
-                     "\\\\\\(?:right\\|big\\|bigg\\|Big\\|Bigg\\)?r?" "" right-str)))
+                     "\\\\\\(?:right\\|big\\|bigg\\|Big\\|Bigg\\)" "" right-str)))
              (t (cons (concat "\\left" left-str)
                       (concat "\\right" right-str))))
           (evil-tex--overlay-replace left-over  l)


### PR DESCRIPTION
I started working on this because I wasn't getting appropriate behavior when firing `evil-tex-toggle-delim` in the following scenario (`|` is point)

```
$\{ x^2| \}$
```

would become

```
${ x^2| }$
```

rather than

```
$\left\{ x^2| \right\}$
```

Previously, the regex it used to decide if the delimiters are already
balanced (based just on the initial one) is:

`"\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)?l?"`

(note: all regexes here are taken from elisp so have extra backslashes for
string escapes)

The trouble is that this matches *anything* that has a slash, since everything
that follows is optional. For example, if you have math like $ \{ x \} $ and you
run evil-tex-toggle-delim, then this *will* match (just the literal backslash),
causing it to think that it is already size balanced, and then "toggling" will
just strip the backslash rather than prepending \left and \right.

This could be fixed by changing it to

`"\\\\\\(?:\\(left\\|big\\|bigg\\|Big\\|Bigg\\)\\|l\\)"`

This extra level of grouping means that it only matches if there is a literal
backslash followed by *either* one of the balancing keywords OR l. This way it
has to match something in the second part, and this will not match \{

However, I think that trailing (optional) l is perhaps a mistake. I assume it is
there to catch things like \langle, but this will then toggle \langle to
angle (which without the slash is not a macro). Moreover, \langle and
\rangle (or similarly \lvert and \rvert, see #17, etc) are paired delimiters but they do
not automatically resize (at least not for me), I instead need to do
\left\langle if I want that behavior. For that reason, I think the trailing l
should be cut, and the final regex is just

`"\\\\\\(?:left\\|big\\|bigg\\|Big\\|Bigg\\)"`