### PR TITLE
readme: Documentation improvements

### DIFF
--- a/README.org
+++ b/README.org
@@ -86,8 +86,8 @@ This package defines a number of text objects:
 | ~^~ | superscript     | ~x^a~ ~x^\alpha~ ~x^{...}~                                               | Surrounds with ~^{ }~                      |
 | ~_~ | subscript       | ~x_a~ ~x_\alpha~ ~x_{...}~                                               | Surrounds with ~_{ }~                      |
 | ~T~ | table cell      | LaTeX table/align cells, e.g. ~&foo&~.                                   | Surrounds with ~& &~                       |
-| ~q~ | single quote    | LaTeX single quote, like `this'                                          | Surrounds with ~` '~                       |
-| ~Q~ | double quote    | LaTeX double quote, like ``this''                                        | Surrounds with ~`` ''~                     |
+| ~q~ | single quote    | LaTeX single quote, like ~​`this'​~                                        | Surrounds with ~​` '​~                       |
+| ~Q~ | double quote    | LaTeX double quote, like ~​``this''​~                                       | Surrounds with ~​`` ''​~                     |
 
 The full text object definitions are as follows:
 

--- a/README.org
+++ b/README.org
@@ -300,7 +300,7 @@ See [[https://github.com/cdominik/cdlatex/blob/a5cb624ef/cdlatex.el#L141][cdlate
 | ~c~ |             | ~\left\{~      | ~\right\}~      |
 | ~R~ | ??          | ~\langle~      | ~\rangle~       |
 | ~r~ |             | ~\left\langle~ | ~\right\rangle~ |
-| ~v~ | vert        | ~\left\lvert~  | ~\right\rvert~  |
-| ~V~ |             | ~\lvert~       | ~\rvert~        |
-| ~n~ | norm        | ~\left\lVert~  | ~\right\rVert~  |
-| ~N~ |             | ~\lVert~       | ~\rVert~        |
+| ~V~ | vert        | ~\lvert~       | ~\rvert~        |
+| ~v~ |             | ~\left\lvert~  | ~\right\rvert~  |
+| ~N~ | norm        | ~\lVert~       | ~\rVert~        |
+| ~n~ |             | ~\left\lVert~  | ~\right\rVert~  |


### PR DESCRIPTION
First, I added some zero-width spaces to make `~` and backticks play nice together when GitHub renders the readme.org file.

Second, I permuted the documentation I added to the delimiter table to follow the "Capitals first" convention.