### PR TITLE
fixed evil-tex operating on wrong math object

### DIFF
--- a/evil-tex.el
+++ b/evil-tex.el
@@ -98,9 +98,6 @@ chose [[\\left(]] over \\left[[(]], etc."
 		     (<= rdax 0)))
 	   (iny (and (>= lday 0)
 		     (<= rday 0))))
-      (message "x: %s y: %s" x y)
-      (message (format "inx: %s, iny: %s" inx iny))
-      (message (format "ldix: %s, ldiy: %s" ldix ldiy))
       (cond
        ;; both in front
        ((and (not inx) (not iny)) (cond
@@ -275,7 +272,6 @@ Math includes inline and display math, e.g. \\(foo\\), \\=\\[bar\\], and $baz$"
       (nconc (nbutlast (ignore-errors (apply #'evil-select-quote ?$ (append args '(t)))) 3)
 	    (nbutlast (ignore-errors (apply #'evil-select-quote ?$ (append args '(nil)))) 3))))
    (lambda (arg) (when (consp arg)  ; check if selection succeeded
-		   (message (format "%s" arg))
                    arg))
    #'evil-tex--delim-compare))
 

--- a/evil-tex.el
+++ b/evil-tex.el
@@ -133,9 +133,6 @@ ARGS passed to `evil-select-paren', within `evil-tex--delim-finder'."
                           ( "\\Bigl"  "\\Bigr")  ("\\Big"  "\\Big")
                           ( "\\Biggl" "\\Biggr") ("\\Bigg" "\\Bigg"))
                      collect (evil-tex--delim-finder (concat pre-l l) (concat pre-r r) args)))
-   (lambda (arg) (when (and (consp arg) ; selection succeeded
-                            ;; selection includes point
-                            (<= (nth 2 arg) (point) (nth 3 arg)))
                    arg))
    #'evil-tex--delim-compare))
 

--- a/evil-tex.el
+++ b/evil-tex.el
@@ -76,24 +76,6 @@ Comparison is done with COMPARE-FN if defined, and with `>' if not.
                 res cur))))
     res))
 
-;; (defun evil-tex--delim-compare (x y)
-;;   "Return t if the X delims are closer the point than Y.
-
-;; X and Y have the format of (left-outer right-outer left-inner right-inner),
-;; chose [[\\left(]] over \\left[[(]], etc."
-;;   (let ((lax (nth 0 x))
-;;         (lix (nth 2 x))
-;;         (lay (nth 0 y))
-;;         (liy (nth 2 y))
-;; 	(point (point)))
-;;     (message "x: %s y: %s" x y)
-;;     (cond
-;;      ((not x)                           nil)
-;;      ((not y)                           t)
-;;      ((< (- lix point) (- liy point))   t)
-;;      ((and (= lix liy) (< lax lay))     t)
-;;      (t nil))))
-
 (defun evil-tex--delim-compare (x y)
   "Return t if the X delims are closer the point than Y.
 
@@ -291,12 +273,7 @@ Math includes inline and display math, e.g. \\(foo\\), \\=\\[bar\\], and $baz$"
                                              (regexp-quote "\\[") (regexp-quote "\\]") (append args '(nil)))) 3)))
     (save-excursion
       (nconc (nbutlast (ignore-errors (apply #'evil-select-quote ?$ (append args '(t)))) 3)
-	    (nbutlast (ignore-errors (apply #'evil-select-quote ?$ (append args '(nil)))) 3))
-      ;; (nconc (nbutlast (ignore-errors (let ((evil-forward-quote-char ?$))
-      ;; 					(apply #'evil-select-quote-thing 'evil-quote (append args '(t))))) 3)
-      ;; 	     (nbutlast (ignore-errors (let ((evil-forward-quote-char ?$))
-      ;; 					(apply #'evil-select-quote-thing 'evil-quote (append args '(nil))))) 3))
-      ))
+	    (nbutlast (ignore-errors (apply #'evil-select-quote ?$ (append args '(nil)))) 3))))
    (lambda (arg) (when (consp arg)  ; check if selection succeeded
 		   (message (format "%s" arg))
                    arg))


### PR DESCRIPTION
Fixes #22 

Took a little while to track it down but it seems that the function `evil-tex--select-math` could move the point inadvertantly messing up the logic of the whole function, seems to have been solved by just wrapping the key bits with calls to `save-excursion`. 