### PR TITLE
fix: missed condition in delim comparison

### DIFF
--- a/evil-tex.el
+++ b/evil-tex.el
@@ -108,6 +108,7 @@ chose [[\\left(]] over \\left[[(]], etc."
        ;; neither in front (both in)
        ((and iny inx) (cond
                        ((> ldix ldiy) nil)
+		       ((< ldix ldiy) t)
                        ((and (= ldix ldiy) (> ldax lday)) t))))))))
 
 (defun evil-tex--delim-finder (deliml delimr args)


### PR DESCRIPTION
I missed a condition in the delim comparison function before. I just found it :(

Without this fix the following occurs when calling toggle delim from point `|`. 

```
\( \{ | \} \)
```

```
\left\( \{ | \} \right\)
```

Which is clearly not correct. Turns out it was an easy fix. 