### PR TITLE
adding {} to delim text objects

### DIFF
--- a/evil-tex.el
+++ b/evil-tex.el
@@ -139,6 +139,7 @@ ARGS passed to `evil-select-paren', within `evil-tex--delim-finder'."
    (cl-loop for (l r)
             in '(( "(" ")" )
                  ( "[" "]" )
+                 ( "\{" "\}" )
                  ( "\\{" "\\}" )
                  ( "\\langle" "\\rangle" )
                  ( "\\lvert" "\\rvert" )


### PR DESCRIPTION
Very small pull request to include `{` and `}` in evil-tex--delim-finder and not just `\{` `\}`. 

In my mind this comes with very little cost in that if `\{` `\}` is present the way text objects in evil-tex are already written it will default to the correct behavior. This just extends to the case where there is a non-escaped curly brace in a math environment. 

I find this useful in cases where I have $ f^{xy} $ and I want to quicky change this to $ f^z $. 